### PR TITLE
Automatically add domains to certificate

### DIFF
--- a/auto-letsencrypt/entrypoint.sh
+++ b/auto-letsencrypt/entrypoint.sh
@@ -20,7 +20,7 @@ WEBROOT_PATH="${WEBROOT_PATH:-"/var/www"}"
 check() {
   echo "* Starting webroot initial certificate request script..."
 
-  certbot certonly --webroot --agree-tos --noninteractive --text \
+  certbot certonly --webroot --agree-tos --noninteractive --text --expand \
       --email ${EMAIL} \
       --webroot-path ${WEBROOT_PATH} \
       ${CERTBOT_DOMAINS}


### PR DESCRIPTION
After adding a new domain into DOMAINS variable this container doesn't renew the certificate automatically.

Log: [letsencrypt.txt](https://github.com/gchan/dockerfiles/files/564935/letsencrypt.txt)

